### PR TITLE
refactor: Promote DevTweakerFix.Info To Package-Private Class And Rename To TweakInfo

### DIFF
--- a/src/main/java/net/llvg/dev_tweaker_fix/TweakInfo.java
+++ b/src/main/java/net/llvg/dev_tweaker_fix/TweakInfo.java
@@ -1,0 +1,31 @@
+package net.llvg.dev_tweaker_fix;
+
+/**
+ * <p>
+ * A bundle of tweaker {@code clazz} and {@code order}.<br>
+ * Be used in tweaker sorting.
+ * </p>
+ */
+final class TweakInfo
+  implements Comparable<TweakInfo>
+{
+    private final String tweak;
+    private final int order;
+    
+    public TweakInfo(
+      String tweak,
+      int order
+    ) {
+        this.tweak = tweak;
+        this.order = order;
+    }
+    
+    public String getTweak() {
+        return tweak;
+    }
+    
+    @Override
+    public int compareTo(TweakInfo o) {
+        return Integer.compare(order, o.order);
+    }
+}


### PR DESCRIPTION
# Backend Changes

- Promote `DevTweakerFix.Info` to package-private class
  - Rename the class to `TweakInfo`
  - Rename the field `clazz` to `tweak`
  - Implement `java.lang.Comparable`

- Add default constructor with javadoc into `DevTweakerFix`

- Use natural ordering in `TweakInfo` sorting since it's now implemented `java.lang.Comparable`